### PR TITLE
fix fetch events tools + not need for signer ndk setup env to fetch

### DIFF
--- a/askeladd-dvm-marketplace/src/app/page.tsx
+++ b/askeladd-dvm-marketplace/src/app/page.tsx
@@ -123,7 +123,7 @@ export default function Home() {
         // const relay = await Relay.connect(ASKELADD_RELAY[0])
         // let eventID = await relay.publish(event as EventNostr);
         const eventID = await Promise.any(pool.publish(ASKELADD_RELAY, event as EventNostr));
-        const { events } = await fetchEvents({
+        const { events } = await fetchEventsTools({
           kind: KIND_JOB_REQUEST,
           since: timestampJob
         });
@@ -176,6 +176,8 @@ export default function Home() {
         // })
         setIsWaitingJob(true)
       } else {
+
+        /** @TODO flow is user doesn't have NIP-07 extension */
         // let { result, event } = await sendNote({ content, tags, kind: 5600 })
         // console.log("event", event)
         // if (event?.sig) {
@@ -205,7 +207,7 @@ export default function Home() {
     //   const { events } = await fetchEventsTools({ until: timestampJob, kind: KIND_JOB_RESULT, 
     //     // search:`${jobId}`,
     //  })
-    const { events } = await fetchEvents({
+    const { events } = await fetchEventsTools({
       kind: KIND_JOB_RESULT,
       // since: timestampJob,
       // search:`${jobId}`,

--- a/askeladd-dvm-marketplace/src/context/NostrContext.tsx
+++ b/askeladd-dvm-marketplace/src/context/NostrContext.tsx
@@ -30,7 +30,7 @@ export const NostrProvider: React.FC<React.PropsWithChildren> = ({children}) => 
     newNdk.connect().then(() => {
       setNdk(newNdk);
     });
-  }, [privateKey, process.env.DEFAULT_NOSTR_USER_SK]);
+  }, [privateKey, process.env.NEXT_PUBLIC_DEFAULT_NOSTR_USER_SK]);
 
   return <NostrContext.Provider value={{ndk}}>{children}</NostrContext.Provider>;
 };

--- a/askeladd-dvm-marketplace/src/hooks/useFetchEvents.ts
+++ b/askeladd-dvm-marketplace/src/hooks/useFetchEvents.ts
@@ -17,11 +17,11 @@ interface ISubscriptionData {
 const DEFAULT_LIMIT = 300
 export const useFetchEvents = () => {
   const { ndk } = useNostrContext();
+  // const pool = new SimplePool()
   const [pool, setPool] = useState(new SimplePool())
 
   const fetchEvents = async (data: IEventFilter) => {
     try {
-      if (!ndk?.signer) return { result: undefined, events: undefined };
       const { kind, limit, since, until, kinds, search } = data;
       let eventsResult = await ndk.fetchEvents({
         kinds: kind ? [kind] : kinds ?? [KIND_JOB_RESULT as NDKKind, KIND_JOB_REQUEST],
@@ -44,12 +44,17 @@ export const useFetchEvents = () => {
   }
   const fetchEventsTools = async (data: IEventFilter) => {
     try {
-      if (!ndk?.signer) return { result: undefined, events: undefined };
       const { kind, limit, since, until, kinds, search } = data;
       const pool = new SimplePool()
       let relays = ASKELADD_RELAY;
       const kind_search = kind ? [kind] : kinds ?? [KIND_JOB_REQUEST, KIND_JOB_RESULT];
-      const events = await pool.querySync(relays, { kinds: kind_search, until, since, limit: limit ?? DEFAULT_LIMIT, search })
+      const events = await pool.querySync(relays, {
+        kinds: kind_search,
+        // until,
+        // since,
+        // limit: limit ?? DEFAULT_LIMIT,
+        // search
+      })
       return {
         result: undefined,
         events: events
@@ -90,7 +95,7 @@ export const useFetchEvents = () => {
         }
       }
     )
-    setPool(pool);
+    // setPool(pool);
     return h;
   }
   return { fetchEvents, fetchEventsTools, setupSubscriptionNostr, pool }

--- a/askeladd-dvm-marketplace/src/hooks/useFetchEvents.ts
+++ b/askeladd-dvm-marketplace/src/hooks/useFetchEvents.ts
@@ -50,10 +50,10 @@ export const useFetchEvents = () => {
       const kind_search = kind ? [kind] : kinds ?? [KIND_JOB_REQUEST, KIND_JOB_RESULT];
       const events = await pool.querySync(relays, {
         kinds: kind_search,
-        // until,
-        // since,
-        // limit: limit ?? DEFAULT_LIMIT,
-        // search
+        until,
+        since,
+        limit: limit ?? DEFAULT_LIMIT,
+        search
       })
       return {
         result: undefined,


### PR DESCRIPTION
Fix fetch events

- Delete ndk.signer check
- Nostr tools fetch events

If no NIP-07 extension: 
We can setup a NEXT_PUBLIC_DEFAULT_NOSTR_USER_SK 
Now it's not needed to fetch events correctly (causing the issue of the flow).
